### PR TITLE
fix!: Improve cache refresh coverage and archive cache artifacts

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           path: output/cache
           key: output-cache-${{ runner.os }}-${{ github.ref_name }}-v1-${{ github.run_id }}
+      - name: Upload cache artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-cache-${{ github.run_id }}
+          path: output/cache
+          retention-days: 14
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,6 +147,7 @@ async function main() {
 
         if (previous.version !== entry.version) {
             previous.version = entry.version;
+            previous.checkedAt = "";
             previous.rustDependency = "unknown";
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,13 +76,32 @@ function installLogCacheKey(packageName: string, flavor: string): string {
     return `${packageName}::${flavor}`;
 }
 
-function mayRequireRustFromSystemRequirements(systemRequirements: string): boolean {
-    return /\brustc\b|\bcargo\b|\brust\b/i.test(systemRequirements);
-}
-
 function toTimestampOrMin(iso: string): number {
     const time = Date.parse(iso);
     return Number.isNaN(time) ? Number.MIN_SAFE_INTEGER : time;
+}
+
+function packageRotationSalt(): number {
+    // Daily deterministic rotation to avoid lexical bias when checkedAt ties.
+    const daysSinceEpoch = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+    return daysSinceEpoch;
+}
+
+function hashPackageName(name: string): number {
+    let hash = 2166136261;
+    for (let i = 0; i < name.length; i += 1) {
+        hash ^= name.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}
+
+function packageRotationScore(name: string, salt: number): number {
+    return (hashPackageName(name) + (salt >>> 0)) >>> 0;
+}
+
+function jsonSizeBytes(value: unknown): number {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
 }
 
 async function main() {
@@ -102,41 +121,60 @@ async function main() {
             .map((entry) => entry.packageName),
     );
 
-    const candidatePackages = new Set<string>();
     const entriesToRefresh: Array<{
         entry: PackageIndexEntry;
         lastCheckedAt: string;
     }> = [];
+
     for (const entry of packageIndex) {
-        const previous = packageCheck.packages[entry.packageName];
         if (!entry.needsCompilation) {
             continue;
         }
 
-        if (previous && previous.version === entry.version) {
-            candidatePackages.add(entry.packageName);
+        const previous = packageCheck.packages[entry.packageName];
+        if (!previous) {
+            packageCheck.packages[entry.packageName] = {
+                version: entry.version,
+                checkedAt: "",
+                rustDependency: "unknown",
+            };
+            entriesToRefresh.push({
+                entry,
+                lastCheckedAt: "",
+            });
             continue;
         }
 
-        // On cold start, skip obvious non-Rust packages using cheap metadata.
-        if (!previous && entry.systemRequirements !== "") {
-            if (!mayRequireRustFromSystemRequirements(entry.systemRequirements)) {
-                continue;
-            }
+        if (previous.version !== entry.version) {
+            previous.version = entry.version;
+            previous.rustDependency = "unknown";
+        }
+
+        if (
+            previous.version === entry.version &&
+            previous.rustDependency !== "unknown"
+        ) {
+            continue;
         }
 
         entriesToRefresh.push({
             entry,
-            lastCheckedAt: previous?.checkedAt ?? "",
+            lastCheckedAt: previous.checkedAt,
         });
     }
 
     // Prefer least-recently checked packages so coverage progresses across runs.
+    const rotationSalt = packageRotationSalt();
     entriesToRefresh.sort((a, b) => {
         const checkedAtDiff = toTimestampOrMin(a.lastCheckedAt) -
             toTimestampOrMin(b.lastCheckedAt);
         if (checkedAtDiff !== 0) {
             return checkedAtDiff;
+        }
+        const rotationDiff = packageRotationScore(a.entry.packageName, rotationSalt) -
+            packageRotationScore(b.entry.packageName, rotationSalt);
+        if (rotationDiff !== 0) {
+            return rotationDiff;
         }
         return a.entry.packageName.localeCompare(b.entry.packageName);
     });
@@ -157,6 +195,7 @@ async function main() {
                 const cacheEntry: PackageCheckEntry = {
                     version: entry.version,
                     checkedAt: new Date().toISOString(),
+                    rustDependency: rustDependent ? "rust" : "not_rust",
                 };
                 return {
                     packageName: entry.packageName,
@@ -172,19 +211,13 @@ async function main() {
             if (item.status === "error" || item.status === "not_found") {
                 // Keep the previous decision on transient API failures.
                 if (previous) {
-                    // Preserve the last evaluated version so newer versions are retried.
+                    // Preserve the last evaluated state so newer versions are retried.
                     packageCheck.packages[item.packageName] = previous;
-                    candidatePackages.add(item.packageName);
                 }
                 continue;
             }
 
-            if (item.rustDependent) {
-                packageCheck.packages[item.packageName] = item.cacheEntry;
-                candidatePackages.add(item.packageName);
-            } else {
-                delete packageCheck.packages[item.packageName];
-            }
+            packageCheck.packages[item.packageName] = item.cacheEntry;
         }
     }
 
@@ -194,7 +227,20 @@ async function main() {
         }
     }
 
+    const candidatePackages = new Set(
+        Object.entries(packageCheck.packages)
+            .filter(([, value]) => value.rustDependency === "rust")
+            .map(([packageName]) => packageName),
+    );
+
+    const totalCompilationPackages = compilationPackageNames.size;
+    const rustDependentPackages = candidatePackages.size;
+    console.log(
+        `Compilation packages: ${totalCompilationPackages}, rust-dependent: ${rustDependentPackages}, refresh targets this run: ${refreshTargets.length}`,
+    );
+
     const installLogs = await fetchInstallTxtLinksForPackages(candidatePackages);
+    console.log(`Install logs to inspect: ${installLogs.length}`);
 
     const versions: VersionInfo[] = [];
     const observedKeys = new Set<string>();
@@ -358,13 +404,19 @@ async function main() {
     await Deno.writeTextFile(versionsJsonPath, versionsJson);
     packageCheck.updatedAt = new Date().toISOString();
     installLogCache.updatedAt = new Date().toISOString();
+    console.log(
+        `Cache entries: package-check=${Object.keys(packageCheck.packages).length}, install-logs=${Object.keys(installLogCache.logs).length}`,
+    );
+    console.log(
+        `Cache size (bytes): package-check=${jsonSizeBytes(packageCheck)}, install-logs=${jsonSizeBytes(installLogCache)}`,
+    );
     await Deno.writeTextFile(
         PACKAGE_CHECK_PATH,
-        JSON.stringify(packageCheck, null, 2),
+        JSON.stringify(packageCheck),
     );
     await Deno.writeTextFile(
         INSTALL_LOG_CACHE_PATH,
-        JSON.stringify(installLogCache, null, 2),
+        JSON.stringify(installLogCache),
     );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ export type RUniversePackageFetchResult =
 export interface PackageCheckEntry {
     version: string;
     checkedAt: string;
+    rustDependency: "unknown" | "rust" | "not_rust";
 }
 
 export interface PackageCheckFile {


### PR DESCRIPTION
## Summary
- cache `package-check` schema now tracks rust dependency state explicitly (`unknown`/`rust`/`not_rust`) for compilation packages
- refresh tie-break on equal `checkedAt` now uses deterministic daily rotation score instead of lexical order to reduce a-c bias
- cache files are written as minified JSON
- upload `output/cache` as a GitHub Actions artifact (14-day retention) for post-run inspection
- add run metrics logs for package counts and cache size

## Why
- observed behavior was biased toward early alphabetical packages during refresh cycles
- wanted to improve cache coverage progression and make cache inspection possible from GHA runs

## Validation
- `deno check src/main.ts` passed
