### PR TITLE
fix: prevent version downgrade caused by transient fetch errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
     VersionInfo,
 } from "./types/index.ts";
 import { latestVersions } from "./utils.ts";
-import { compare, format, parse } from "./deps.ts";
+import { compare, format, greaterThan, parse, type SemVer } from "./deps.ts";
 
 const PACKAGE_CHECK_PATH = "./output/cache/package-check.json";
 const INSTALL_LOG_CACHE_PATH = "./output/cache/install-logs.json";
@@ -245,6 +245,7 @@ async function main() {
 
     const versions: VersionInfo[] = [];
     const observedKeys = new Set<string>();
+    const fetchFailuresByFlavor = new Set<string>();
     const cacheStats = { fresh: 0, validated: 0, fetched: 0 };
     for (
         let i = 0;
@@ -267,6 +268,7 @@ async function main() {
                     if (cachedRustc && format(cachedRustc) !== "0.0.0") {
                         return {
                             key,
+                            flavor: log.flavor,
                             version: {
                                 flavor: cached.flavor,
                                 rustc: cachedRustc,
@@ -274,9 +276,10 @@ async function main() {
                             cacheEntry: null,
                             dropCache: false,
                             cacheStatus: "fresh" as const,
+                            fetchFailed: false,
                         };
                     }
-                    return { key, version: null, cacheEntry: null, dropCache: false, cacheStatus: "fresh" as const };
+                    return { key, flavor: log.flavor, version: null, cacheEntry: null, dropCache: false, cacheStatus: "fresh" as const, fetchFailed: false };
                 }
 
                 let validator = "";
@@ -294,6 +297,7 @@ async function main() {
                     if (cachedRustc && format(cachedRustc) !== "0.0.0") {
                         return {
                             key,
+                            flavor: log.flavor,
                             version: {
                                 flavor: cached.flavor,
                                 rustc: cachedRustc,
@@ -301,6 +305,7 @@ async function main() {
                             cacheEntry: null,
                             dropCache: false,
                             cacheStatus: "validated" as const,
+                            fetchFailed: false,
                         };
                     }
                     // Re-fetch when cache content is unusable even if validator matches.
@@ -317,6 +322,7 @@ async function main() {
                 if (versionInfo && format(versionInfo.rustc) !== "0.0.0") {
                     return {
                         key,
+                        flavor: log.flavor,
                         version: versionInfo,
                         cacheEntry: {
                             packageName: log.packageName,
@@ -328,14 +334,17 @@ async function main() {
                         },
                         dropCache: false,
                         cacheStatus: "fetched" as const,
+                        fetchFailed: false,
                     };
                 }
 
+                const fetchFailed = versionInfo === null;
                 if (cached && cached.url === log.url) {
                     // Avoid reusing stale rustc after a detected validator update.
                     if (validator !== "" && cached.validator !== validator) {
                         return {
                             key,
+                            flavor: log.flavor,
                             version: null,
                             cacheEntry: {
                                 packageName: log.packageName,
@@ -347,24 +356,29 @@ async function main() {
                             },
                             dropCache: false,
                             cacheStatus: "fetched" as const,
+                            fetchFailed,
                         };
                     }
 
                     return {
                         key,
+                        flavor: log.flavor,
                         version: null,
                         cacheEntry: null,
                         dropCache: false,
                         cacheStatus: "fetched" as const,
+                        fetchFailed,
                     };
                 }
 
                 return {
                     key,
+                    flavor: log.flavor,
                     version: null,
                     cacheEntry: null,
                     dropCache: true,
                     cacheStatus: "fetched" as const,
+                    fetchFailed,
                 };
             }),
         );
@@ -379,6 +393,9 @@ async function main() {
                 installLogCache.logs[result.key] = result.cacheEntry;
             } else if (result.dropCache) {
                 delete installLogCache.logs[result.key];
+            }
+            if (result.cacheStatus === "fetched" && result.fetchFailed) {
+                fetchFailuresByFlavor.add(result.flavor);
             }
         }
     }
@@ -400,8 +417,35 @@ async function main() {
             return compare(a.rustc, b.rustc);
         });
 
+    const versionsJsonPath = "./output/versions.json";
+    const existingVersionFloor = new Map<string, SemVer>();
+    try {
+        const existingRaw = await Deno.readTextFile(versionsJsonPath);
+        const existingData = JSON.parse(existingRaw) as Array<{ flavor: string; rustc: string }>;
+        for (const entry of existingData) {
+            try {
+                existingVersionFloor.set(entry.flavor, parse(entry.rustc));
+            } catch {
+                // skip unparseable entries
+            }
+        }
+    } catch {
+        // no existing file or parse error, start fresh
+    }
+
+    const adjustedVersions = uniqueVersions.map((version) => {
+        const floor = existingVersionFloor.get(version.flavor);
+        if (floor && greaterThan(floor, version.rustc) && fetchFailuresByFlavor.has(version.flavor)) {
+            console.warn(
+                `Version downgrade prevented for ${version.flavor}: computed ${format(version.rustc)} < existing ${format(floor)} (fetch errors occurred this run)`
+            );
+            return { ...version, rustc: floor };
+        }
+        return version;
+    });
+
     const versionsJson = JSON.stringify(
-        uniqueVersions.map((version) => {
+        adjustedVersions.map((version) => {
             return {
                 flavor: version.flavor,
                 rustc: format(version.rustc),
@@ -410,7 +454,6 @@ async function main() {
         null,
         4,
     );
-    const versionsJsonPath = "./output/versions.json";
     await Deno.mkdir("./output", { recursive: true });
     await Deno.mkdir("./output/cache", { recursive: true });
     await Deno.writeTextFile(versionsJsonPath, versionsJson);

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,7 +279,15 @@ async function main() {
                             fetchFailed: false,
                         };
                     }
-                    return { key, flavor: log.flavor, version: null, cacheEntry: null, dropCache: false, cacheStatus: "fresh" as const, fetchFailed: false };
+                    return {
+                        key,
+                        flavor: log.flavor,
+                        version: null,
+                        cacheEntry: null,
+                        dropCache: false,
+                        cacheStatus: "fresh" as const,
+                        fetchFailed: false,
+                    };
                 }
 
                 let validator = "";
@@ -421,16 +429,22 @@ async function main() {
     const existingVersionFloor = new Map<string, SemVer>();
     try {
         const existingRaw = await Deno.readTextFile(versionsJsonPath);
-        const existingData = JSON.parse(existingRaw) as Array<{ flavor: string; rustc: string }>;
-        for (const entry of existingData) {
-            try {
-                existingVersionFloor.set(entry.flavor, parse(entry.rustc));
-            } catch {
-                // skip unparseable entries
+        try {
+            const existingData = JSON.parse(existingRaw) as Array<{ flavor: string; rustc: string }>;
+            for (const entry of existingData) {
+                try {
+                    existingVersionFloor.set(entry.flavor, parse(entry.rustc));
+                } catch {
+                    // skip unparseable entries
+                }
             }
+        } catch {
+            console.warn(`Failed to parse existing ${versionsJsonPath}; downgrade protection disabled for this run.`);
         }
-    } catch {
-        // no existing file or parse error, start fresh
+    } catch (e) {
+        if (!(e instanceof Deno.errors.NotFound)) {
+            console.warn(`Failed to read existing ${versionsJsonPath}; downgrade protection disabled for this run.`);
+        }
     }
 
     const adjustedVersions = uniqueVersions.map((version) => {
@@ -442,6 +456,11 @@ async function main() {
             return { ...version, rustc: floor };
         }
         return version;
+    }).sort((a, b) => {
+        if (compare(a.rustc, b.rustc) === 0) {
+            return a.flavor.localeCompare(b.flavor);
+        }
+        return compare(a.rustc, b.rustc);
     });
 
     const versionsJson = JSON.stringify(


### PR DESCRIPTION
## Summary

- Track fetch failures (network/HTTP errors) per flavor via `fetchFailuresByFlavor` during install log processing
- Before writing `versions.json`, load the existing file and keep the existing version for any flavor where the computed version would be lower and fetch errors occurred this run
- Genuine downgrades (all fetches successful, all packages consistently show a lower version) still pass through normally

## Motivation

As seen in PR #83, a transient fetch error on a CRAN check page could cause a stale cached version to win the `latestVersions` aggregation, producing a PR that downgrades a flavor (e.g. `r-oldrel-macos-arm64`: 1.93.0 → 1.91.1). These PRs required manual review to catch.

## Known limitation

If some packages for a flavor fail while others successfully fetch a genuinely lower version, the downgrade is still blocked. However, since the Rust version is determined per CRAN check machine (all packages share the same Rust), this scenario is rare. The downgrade will pass through on the next run once fetch errors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)